### PR TITLE
Fix ssh disconnection on compute nodes

### DIFF
--- a/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
+++ b/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ "$SLURM_JOB_USER" != root ]; then
-    if killall -9 -u "$SLURM_JOB_USER" ; then
+# Retrieve slurm user processes
+ps h -u $SLURM_JOB_USER | while read PROCESS
+do
+    PID=`echo $PROCESS | awk '{print $1}'`
+    PNAME=`echo $PROCESS | awk '{print $5}'`
+
+    # Kill residual user processes except: user ssh connection to compute nodes
+    # "sshd:" : A process created for ssh connection
+    # "-bash" : A shell process which is child of ssh connection
+    if [ "$PNAME" != "-bash" -a "$PNAME" != "sshd:" ]; then
+        kill -9 $PID
         logger -s -t slurm-epilog 'Killed residual user processes'
     fi
-fi
+done

--- a/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
+++ b/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 set -ex
 
-# Retrieve slurm user processes
-ps h -u $SLURM_JOB_USER | while read PROCESS
-do
-    PID=`echo $PROCESS | awk '{print $1}'`
-    PNAME=`echo $PROCESS | awk '{print $5}'`
+if [ "$SLURM_JOB_USER" != root ]; then
+    # Retrieve slurm user processes
+    ps h -u $SLURM_JOB_USER | while read PROCESS
+    do
+        PID=`echo $PROCESS | awk '{print $1}'`
+        PNAME=`echo $PROCESS | awk '{print $5}'`
 
-    # Kill residual user processes except: user ssh connection to compute nodes
-    # "sshd:" : A process created for ssh connection
-    # "-bash" : A shell process which is child of ssh connection
-    if [ "$PNAME" != "-bash" -a "$PNAME" != "sshd:" ]; then
-        kill -9 $PID
-        logger -s -t slurm-epilog 'Killed residual user processes'
-    fi
-done
+        # Kill residual user processes except: user ssh connection to compute nodes
+        # "sshd:" : A process created for ssh connection
+        # "-bash" : A shell process which is child of ssh connection
+        if [ "$PNAME" != "-bash" -a "$PNAME" != "sshd:" ]; then
+            kill -9 $PID
+            logger -s -t slurm-epilog 'Killed residual user processes'
+        fi
+    done
+fi


### PR DESCRIPTION
Once slurm job completed, slurm terminates slurm user's all processes by epilog script.

Suppose the environment that a user connects to compute node by ssh and looks job progress in there, the ssh connection will be lost by killing user processes.

Not to kill the ssh and it's shell (bash) so, the ssh connection will be kept.